### PR TITLE
Read me .md

### DIFF
--- a/.github/workflows/publish-dokka-docs.yml
+++ b/.github/workflows/publish-dokka-docs.yml
@@ -3,7 +3,7 @@ name: Deploy Dokka Docs
 on:
   pull_request:
     branches:
-      - develop  # publish when PR created toward master branch
+      - master  # publish when PR created toward master branch
 
 jobs:
   deployDocs:

--- a/readme.md
+++ b/readme.md
@@ -1,0 +1,6 @@
+# Project Documentation
+
+## Documentation Links
+
+- [JaCoCo Report](https://zainempg.github.io/dubizzle_util/docs/jacoco/)
+- [Dokka Documentation](https://zainempg.github.io/dubizzle_util/docs/dokka/)


### PR DESCRIPTION
…l requests to master

This commit configures a GitHub Actions workflow to publish Dokka-generated documentation to GitHub Pages upon pull requests to the `master` branch and adds documentation links to the README.

- Added `.github/workflows/publish-dokka-docs.yml`:
    - Created a new GitHub Actions workflow named "Publish Dokka Docs".
    - Triggered the workflow on pull requests to the `master` branch.
    - The workflow checks out the code, sets up JDK 17, and then generates Dokka documentation using the `./gradlew dokkaHtml` command.
    - The generated Dokka files are then committed and pushed to the `gh-pages` branch.
- Updated `readme.md`:
    - Added a new section with links to the JaCoCo Report and Dokka Documentation, which will be hosted on GitHub Pages.