### PR TITLE
feat: Update README with GitHub Packages usage instructions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -4,3 +4,22 @@
 
 - [JaCoCo Report](https://zainempg.github.io/dubizzle_util/docs/jacoco/)
 - [Dokka Documentation](https://zainempg.github.io/dubizzle_util/docs/dokka/)
+
+## GitHub Packages
+
+To use the packages from this repository, add the following to your `build.gradle.kts` file:
+
+```kotlin
+repositories {
+    maven {
+        url = uri("https://maven.pkg.github.com/zainempg/dubizzle_util")
+        credentials {
+            username = project.findProperty("gpr.user") as String? ?: System.getenv("USERNAME")
+            password = project.findProperty("gpr.token") as String? ?: System.getenv("TOKEN")
+        }
+    }
+}
+
+dependencies {
+    implementation("com.dubizzle.util:your-package-name:version")
+}


### PR DESCRIPTION
This commit updates the `readme.md` file to include instructions for using the library from GitHub Packages.

-   Added a new section "GitHub Packages" to `readme.md`.
- Added code block to show how to add the repository to the `build.gradle.kts`.
    - The repository URL is set to "https://maven.pkg.github.com/zainempg/dubizzle_util".
    - The credentials section now includes instructions for setting the `username` and `password`.
    - Also provided an example usage instruction within the `dependencies` section.