### PR TITLE
Add DebouncedClickListener for preventing rapid clicks

### DIFF
--- a/dubizzleUtil/src/main/java/com/dubizzle/util/DebouncedClickListener.kt
+++ b/dubizzleUtil/src/main/java/com/dubizzle/util/DebouncedClickListener.kt
@@ -1,0 +1,28 @@
+package dubizzle.com.uilibrary.util
+
+import android.os.SystemClock
+import android.view.View
+
+class DebouncedClickListener(
+    private var defaultInterval: Int = 1000,
+    private val onSafeCLick: (View) -> Unit
+) : View.OnClickListener {
+    private var lastTimeClicked: Long = 0
+    override fun onClick(v: View) {
+        if (SystemClock.elapsedRealtime() - lastTimeClicked < defaultInterval) {
+            return
+        }
+        lastTimeClicked = SystemClock.elapsedRealtime()
+        onSafeCLick(v)
+    }
+}
+
+object DebouncedClickListenerObject {
+    @JvmStatic
+    fun View.setDebounceClickListener(onSafeClick: (View) -> Unit) {
+        val safeClickListener = DebouncedClickListener {
+            onSafeClick(it)
+        }
+        setOnClickListener(safeClickListener)
+    }
+}


### PR DESCRIPTION
This commit introduces a `DebouncedClickListener` class to address the issue of accidental rapid clicks.

-   Added `DebouncedClickListener.kt`:
    -   Implemented the `DebouncedClickListener` class, which extends `View.OnClickListener`.