### PR TITLE
feat: Configure Maven publication for release with updated versioning

### DIFF
--- a/dubizzleUtil/build.gradle.kts
+++ b/dubizzleUtil/build.gradle.kts
@@ -125,8 +125,11 @@ publishing {
     publications {
         create<MavenPublication>("release") {
             groupId = "com.dubizzle"  // Change to your GitHub username
-            artifactId = "util"             // Change to your library name
-            version = System.getenv("VERSION_NAME")?.plus("_beta") ?: "0.0.3"
+            artifactId = "util"       // Change to your library name
+            version = System.getenv("VERSION_NAME")
+                ?.takeIf { it.isNotEmpty() }
+                ?.plus("_beta")
+                ?: "0.0.6"
 
             afterEvaluate {
                 from(components["release"])


### PR DESCRIPTION
This commit configures the Maven publication for the "release" variant and updates the versioning logic.

-   **Updated Maven publication:**
    -   Modified the `version` property of the `release` Maven publication.
    - Now the version is set using the env var "VERSION_NAME" if it is present and not empty.
    - If not it add "_beta" postfix.
    - The default version is changed to "0.0.6".
    - Kept groupId to "com.dubizzle" and artifactId to "util"